### PR TITLE
Support custom Babel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ a string of comma-separated values:
 babel_js_extensions: 'es6, babel, jsx' # Do not process .js files
 ```
 
+You can also pass custom [babel options](https://babeljs.io/docs/en/options) by
+adding the following to your _config.yml:
+
+```yml
+babel_js_options:
+  comments: false
+  compact: true
+```
+
 ## Contributing
 
 1. Fork it (`http://github.com/thejameskyle/jekyll-babel/fork`)

--- a/lib/jekyll-babel/version.rb
+++ b/lib/jekyll-babel/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Babel
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/jekyll/converters/babel.rb
+++ b/lib/jekyll/converters/babel.rb
@@ -5,7 +5,8 @@ module Jekyll
       priority :low
 
       DEFAULT_CONFIGURATION = {
-        'babel_js_extensions' => 'js, es6, babel, jsx'
+        'babel_js_extensions' => 'js, es6, babel, jsx',
+        'babel_js_options' => {}
       }
 
       def initialize(config = {})
@@ -22,6 +23,7 @@ module Jekyll
 
       def convert(content)
         ::Babel::Transpiler.transform(content)['code']
+        ::Babel::Transpiler.transform(content, @config['babel_js_options'])['code']
       end
 
       private

--- a/spec/babel_spec.rb
+++ b/spec/babel_spec.rb
@@ -2,9 +2,17 @@ require 'spec_helper'
 
 describe(Jekyll::Converters::Babel) do
   let(:configuration) { Jekyll::Configuration::DEFAULTS }
+  let(:custom_configuration) { Jekyll::Utils.deep_merge_hashes(Jekyll::Configuration::DEFAULTS, {
+    'babel_js_options' => {
+      'comments' => false
+    }
+  }) }
   let(:converter) do
     Jekyll::Converters::Babel.new(configuration)
   end
+  let(:converter_custom_options) {
+    Jekyll::Converters::Babel.new(custom_configuration)
+  }
   let(:babel_content) do
     <<-BABEL
 /* Functions: */
@@ -39,6 +47,25 @@ var math = {
 };
 JS
   end
+  let(:js_custom_content) do
+    <<-JS
+"use strict";
+
+var square = function square(x) {
+  return x * x;
+};
+
+var list = [1, 2, 3, 4, 5];
+
+var math = {
+  root: Math.sqrt,
+  square: square,
+  cube: function cube(x) {
+    return x * square(x);
+  }
+};
+JS
+  end
 
   context "matching file extensions" do
     it "matches .babel files" do
@@ -58,4 +85,9 @@ JS
     end
   end
 
+  context "accepts custom options" do
+    it "produces JS" do
+      expect(converter_custom_options.convert(babel_content)).to eql(js_custom_content.chomp)
+    end
+  end
 end


### PR DESCRIPTION
This PR lets the user specify custom options for Babel directly from the
_config.yml file.

I took the patch from @primerano in #6, added tests, and updated the
README.

Close #11 